### PR TITLE
Added settings parameters for gulp commands

### DIFF
--- a/django_gulp/management/commands/collectstatic.py
+++ b/django_gulp/management/commands/collectstatic.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 
+from django.conf import settings
 from django.contrib.staticfiles.management.commands.collectstatic import \
     Command as BaseCommand
 
@@ -30,7 +31,8 @@ class Command(BaseCommand):
                          ':/app/.heroku/node/bin')
             }
 
-        subprocess.Popen(['gulp build --production'],
+        gulp_command = getattr(settings, 'GULP_PRODUCTION_COMMAND', 'gulp build --production')
+        subprocess.Popen([gulp_command],
                          **popen_args).wait()
 
         super(Command, self).handle(*args, **options)

--- a/django_gulp/management/commands/runserver.py
+++ b/django_gulp/management/commands/runserver.py
@@ -17,6 +17,7 @@ from django.contrib.staticfiles.management.commands.runserver import Command \
     as StaticfilesRunserverCommand
 from django.core.management.base import CommandError
 from django.core.servers import basehttp
+from django.conf import settings
 
 from env_tools import load_env
 
@@ -101,8 +102,9 @@ class Command(StaticfilesRunserverCommand):
     def start_gulp(self):
         self.stdout.write('>>> Starting gulp')
 
+        gulp_command = getattr(settings, 'GULP_DEVELOP_COMMAND', 'gulp')
         self.gulp_process = subprocess.Popen(
-            ['gulp'],
+            [gulp_command],
             shell=True,
             stdin=subprocess.PIPE,
             stdout=self.stdout,


### PR DESCRIPTION
In our team we use `gulp dev` and `gulp prod` for our builds. I added 2 django settings parameters to customize these commands.
