### PR TITLE
Pass command to Popen as a string, not a list of one string

### DIFF
--- a/django_gulp/management/commands/collectstatic.py
+++ b/django_gulp/management/commands/collectstatic.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
             }
 
         gulp_command = getattr(settings, 'GULP_PRODUCTION_COMMAND', 'gulp build --production')
-        subprocess.Popen([gulp_command],
+        subprocess.Popen(gulp_command,
                          **popen_args).wait()
 
         super(Command, self).handle(*args, **options)

--- a/django_gulp/management/commands/runserver.py
+++ b/django_gulp/management/commands/runserver.py
@@ -104,7 +104,7 @@ class Command(StaticfilesRunserverCommand):
 
         gulp_command = getattr(settings, 'GULP_DEVELOP_COMMAND', 'gulp')
         self.gulp_process = subprocess.Popen(
-            [gulp_command],
+            gulp_command,
             shell=True,
             stdin=subprocess.PIPE,
             stdout=self.stdout,


### PR DESCRIPTION
I was using this package on Windows and came across this error:

```
(venv) PS C:\Users\czlee\git\tabbycat> dj runserver
>>> Starting gulp
>>> gulp process on pid 11284
'"npm run gulp"' is not recognized as an internal or external command,
operable program or batch file.
```

```
(venv) PS C:\Users\czlee\git\tabbycat> dj collectstatic
'"npm run gulp build --production"' is not recognized as an internal or external command,
operable program or batch file.
```

I only saw this error on Windows; it's been working fine on Ubuntu.

I think the issue is that the `subprocess.Popen` object is attempting to interpret the entire string as a single first argument, rather than a whole command comprising space-delimited arguments. From [Python docs](https://docs.python.org/3/library/subprocess.html#subprocess.Popen):

> If _shell_ is _True_, it is recommended to pass _args_ as a string rather than as a sequence.

This pull request just removes the wrapping of the gulp commands in a list, so that it is passed to `Popen` directly as a string. I tried this on both Windows and Ubuntu, and it works on both (that is, there's no apparent effect on Ubuntu).

To provide some context, our [settings.py file](https://github.com/czlee/tabbycat/blob/9439a64/settings.py#L152-L155) has these lines in it:

```
GULP_PRODUCTION_COMMAND = "npm run gulp build --production"
GULP_DEVELOP_COMMAND = "npm run gulp"
```
