### PR TITLE
Add GULP_CWD setting for non-topleve gulpfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Now when you run `./manage.py runserver` or `./manage.py collectstatic` your
 
 ### Settings
 
+`GULP_CWD` defaults to the current working directory. Override it if your `gulpfile.js` does not reside within the Django project's toplevel directory.
+
 `GULP_PRODUCTION_COMMAND` defaults to `gulp build --production`.
-`GULP_DEVELOP_COMMAND` defaults to `gulp`.
+`GULP_DEVELOP_COMMAND` defaults to `gulp`. Note that when specifying this setting manually, `GULP_CWD` is ignored.
 
 ### Heroku
 

--- a/django_gulp/management/commands/collectstatic.py
+++ b/django_gulp/management/commands/collectstatic.py
@@ -33,8 +33,9 @@ class Command(BaseCommand):
                          ':/app/.heroku/node/bin')
             }
 
+        gulp_cwd = getattr(settings, 'GULP_CWD', os.getcwd())
         gulp_command = getattr(
-            settings, 'GULP_PRODUCTION_COMMAND', 'gulp build --production')
+            settings, 'GULP_PRODUCTION_COMMAND', 'gulp build --cwd %s --production' % gulp_cwd)
         try:
             subprocess.check_call(gulp_command, **popen_kwargs)
         except subprocess.CalledProcessError as e:

--- a/django_gulp/management/commands/runserver.py
+++ b/django_gulp/management/commands/runserver.py
@@ -102,7 +102,8 @@ class Command(StaticfilesRunserverCommand):
     def start_gulp(self):
         self.stdout.write('>>> Starting gulp')
 
-        gulp_command = getattr(settings, 'GULP_DEVELOP_COMMAND', 'gulp')
+        gulp_cwd = getattr(settings, 'GULP_CWD', os.getcwd())
+        gulp_command = getattr(settings, 'GULP_DEVELOP_COMMAND', 'gulp --cwd %s' % gulp_cwd)
         self.gulp_process = subprocess.Popen(
             gulp_command,
             shell=True,


### PR DESCRIPTION
A common workflow for me is to have everything related to a web app bundled within one Django app but still be able to use the runserver command and launch gulp *without* having to change the working directory manually (e.g. `cd apps/webapp/static/ && ../../../manage.py runserver` is a bit tedious).

This patch adds a new option `GULP_CWD` that defaults to the current working directory (so, no change in django-gulp's default behavior) and when set calls gulp using the `--cwd` flag.

So using the above example the following would be possible:
```
$ #  $PWD is the Django project's toplevel directory where manage.py resides

$ cat project/settings.py | grep GULP_CWD
GULP_CWD = os.path.join(PROJECT_ROOT, 'apps', 'webgui', 'static')

$ ./manage.py runserver
>>> Starting gulp
>>> gulp process on pid 4242
[16:41:42] Working directory changed to ~/project/apps/webgui/static
[16:41:42] Using gulpfile ~/project/apps/webgui/static/gulpfile.js
```
