### PR TITLE
Fix env-tools dependency spec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
 
     install_requires=[
         'ansicolors==1.0.2',
-        'env_tools==2.0',
+        'env-tools==2.0.0',
         'futures==3.0.5',
         'psutil==4.3.0',
     ],


### PR DESCRIPTION
The canonical package name is `env-tools` with a dash, not an underscore, and the version is `2.0.0`, not `2.0`.

These differences both cause issues with tools such as `pip-compile` (from [pip-tools][pip-tools]) and [hashin][hashin].

We'd really appreciate a quick merge and new release on PyPI if possible.

[pip-tools]: https://github.com/jazzband/pip-tools
[hashin]: https://github.com/peterbe/hashin