### PR TITLE
Add --skip-gulp parameter to collectstatic to disable running gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ INSTALLED_APPS = (
 Now when you run `./manage.py runserver` or `./manage.py collectstatic` your
 `gulp` tasks will run as well!
 
+Furthermore, you can use `./manage.py collectstatic --skip-gulp` to run `collectstatic` without running gulp. This may be useful during development if your gulp build takes a lot of time.
+
 ### Settings
 
 `GULP_CWD` defaults to the current working directory. Override it if your `gulpfile.js` does not reside within the Django project's toplevel directory.


### PR DESCRIPTION
Often, I find myself wasting time by running my lengthy gulp build every time I run collectstatic.

I believe it is valuable to be able to temporarily disable gulp via an optional parameter, `--skip-gulp.`
I did not implement this in `runserver` because a long gulp build does not cause significant blocking.